### PR TITLE
Proxi blue patch 2 cms page custom order

### DIFF
--- a/Block/Cmspage.php
+++ b/Block/Cmspage.php
@@ -58,17 +58,24 @@ class Cmspage extends Categories
         $categoryIds = $this->getCategorySelect();
         if(!$categoryIds) return;
 
-        $sortAttribute = $this->getSortAttribute();    
+        $sortAttribute = $this->getSortAttribute();
         $categories = $this->categoryFactory->create()->getCollection()
                             ->addAttributeToSelect(['name', 'url_key', 'url_path', 'image', 'description'])
                             ->addIdFilter($categoryIds)
                             ->addIsActiveFilter();
 
-        if($sortAttribute == "position") {
-            $categories->addAttributeToSort('level');
+        switch ($sortAttribute) {
+            case 'position':
+                $categories->addAttributeToSort('level');
+                break;
+            case 'custom':
+                // will sort as per order of Id's set in config value: magepow_categories/home_page/category_select
+                $categories->getSelect()->order(new \Zend_Db_Expr('FIELD(e.entity_id,' . $categoryIds . ')'));
+                break;
+            default:
+                $categories->addAttributeToSort($sortAttribute);
+                break;
         }
-
-        $categories->addAttributeToSort($sortAttribute);
 
         return $categories;
     }

--- a/README.md
+++ b/README.md
@@ -94,7 +94,14 @@ Go to `Admin Panel > Stores > Settings > Configuration > Magepow > Categories`
  
 ![config-module-img](https://github.com/magepow/magento-2-categories/blob/master/media/magento-2-categories-10.jpg)
 
-The home page also has the same settings as the category page, except that the home page can choose the display categories instead of excluding the display category.
+The home page also has the same settings as the category page, except that: 
+
+* The home page can choose the display categories instead of excluding the display category.
+* The home page can order the categories by 'custom sort', which will display in the order ids appear in the config value.
+   You can curate this by manually setting the ids in the env.php file to override admin based config.
+   ```
+   ./bin/magento config:set -e magepow_categories/home_page/category_select "64,72,73,1052,68,69,70,1046,65,88,311"
+   ``` 
  * Select the categories displayed on the home page.
 
 ![config-module-img](https://github.com/magepow/magento-2-categories/blob/master/media/magento-2-categories-11.jpg)


### PR DESCRIPTION
It is great widgets can do a custom sort, but homepage can't

This commit ads ability to Home Page to set a custom sort as per order of ids in the config setting (bu not setting them using admin select box, but via cli in env.php)

