### PR TITLE
Update Cmspage.php

### DIFF
--- a/Block/Cmspage.php
+++ b/Block/Cmspage.php
@@ -67,6 +67,7 @@ class Cmspage extends Categories
         switch ($sortAttribute) {
             case 'position':
                 $categories->addAttributeToSort('level');
+                $categories->addAttributeToSort($sortAttribute);
                 break;
             case 'custom':
                 // will sort as per order of Id's set in config value: magepow_categories/home_page/category_select


### PR DESCRIPTION
Add back  sorting by position + level if position sort is enabled. This brings back consistency with older versions, where the selected sort attribute is always injected.

ref: https://github.com/magepow/magento-2-categories/commit/df33eb0eff7150fd3764153b026c4af803ff04b5#diff-3ef7bbd6eb5f485e99abce41ffee2793822d91ac0511baabec7b1ada6589b757R148

this additional sorting by level + position was accidentally drop in later updates.

Old version

![image](https://github.com/user-attachments/assets/dd15670e-fd7f-4646-b425-2c838273d1c9)



