### PR TITLE
Fix: rename getLayout() to getDisplayLayout() — breaks AbstractBlock

### DIFF
--- a/Block/Categories.php
+++ b/Block/Categories.php
@@ -135,7 +135,14 @@ class Categories extends \Magento\Framework\View\Element\Template implements \Ma
         return [self::DEFAULT_CACHE_TAG, self::DEFAULT_CACHE_TAG . '_' . $categoryId];
     }
 
-    public function getLayout()
+    /**
+     * Get the display layout type (grid/list) from config.
+     *
+     * Renamed from getLayout() to avoid overriding AbstractBlock::getLayout()
+     * which must return LayoutInterface. The collision caused fatal errors when
+     * observers or plugins called $block->getParentBlock() or getLayout().
+     */
+    public function getDisplayLayout(): ?string
     {
         return $this->helper->getConfigModule(self::XML_PATH . '/layout');
     }

--- a/Block/Cmspage.php
+++ b/Block/Cmspage.php
@@ -18,7 +18,7 @@ class Cmspage extends Categories
 
     const XML_PATH = 'home_page';
 
-    public function getLayout()
+    public function getDisplayLayout(): ?string
     {
         return $this->helper->getConfigModule(self::XML_PATH . '/layout');
     }

--- a/Block/Widget/Categories.php
+++ b/Block/Widget/Categories.php
@@ -58,7 +58,7 @@ class Categories extends \Magepow\Categories\Block\Categories implements \Magent
         return $this->getData('thumbnail');
     }
     
-    public function getLayout() 
+    public function getDisplayLayout(): ?string
     {
         return 'grid';
     }

--- a/view/frontend/templates/categories.phtml
+++ b/view/frontend/templates/categories.phtml
@@ -17,7 +17,7 @@
  */
 
 $categories       = $block->getCategories();
-$layout           = $block->getLayout();
+$layout           = $block->getDisplayLayout();
 $heading          = $block->getHeading();
 $description      = $block->isShowDescription();
 $itemAmount       = $block->getItemAmount();

--- a/view/frontend/templates/cmspage.phtml
+++ b/view/frontend/templates/cmspage.phtml
@@ -17,7 +17,7 @@
  */
 
 $categories       = $block->getCategories();
-$layout           = $block->getLayout();
+$layout           = $block->getDisplayLayout();
 $heading          = $block->getHeading();
 $description      = $block->isShowDescription();
 $itemAmount       = $block->getItemAmount();


### PR DESCRIPTION
## Problem

Fixes #22

Also reported as part of [uptactics/m2_pvcpipesupplies#351 — Bug 5](https://github.com/uptactics/m2_pvcpipesupplies/issues/351#issuecomment-4401571125)

`Categories`, `Cmspage`, and `Widget\Categories` blocks all override `AbstractBlock::getLayout()` to return a config string (`"grid"`, `"list"`, etc.) instead of a `LayoutInterface` object.

This breaks any code that calls `$block->getParentBlock()` or `$block->getLayout()` on these blocks, because Magento core (`AbstractBlock::getParentBlock()` at line 272) expects `getLayout()` to return a Layout object.

### Error

```
Error: Call to a member function getParentName() on string
in vendor/magento/framework/View/Element/AbstractBlock.php:272
```

This affects any extension that hooks into `view_block_abstract_to_html_after` and calls `getParentBlock()` — including Loki Checkout, which installs an observer on every frontend block.

## Fix

Renamed `getLayout()` → `getDisplayLayout()` in all 3 block classes and updated both frontend templates (`categories.phtml`, `cmspage.phtml`) to call the new method name.

The method was only used to get a CSS layout class name (grid/list), not the Magento Layout object. This was a naming collision, not an intentional override.

## Files Changed

- `Block/Categories.php` — renamed method
- `Block/Cmspage.php` — renamed method
- `Block/Widget/Categories.php` — renamed method
- `view/frontend/templates/categories.phtml` — updated call
- `view/frontend/templates/cmspage.phtml` — updated call

## Note for Hyva Compatibility Module

`hyva-themes/magento2-magepow-categories` also calls `$block->getLayout()` in its template overrides and will need a corresponding update.

empty